### PR TITLE
Migrate from fastai2 to fastai

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,8 @@ repos:
   - id: mixed-line-ending
     args: ['--fix=no']
   - id: flake8
-    args: ['--max-line-length=88', '--ignore=E203']  # default of Black
+    args: ['--ignore=E203,E501,F811']  # default of Black
+    # F811 is necessary to allow multiple dispatch function redefinition
 
 - repo: https://github.com/pre-commit/mirrors-isort
   rev: v4.3.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   - id: mixed-line-ending
     args: ['--fix=no']
   - id: flake8
-    args: ['--max-line-length=88']  # default of Black
+    args: ['--max-line-length=88', '--ignore=E203']  # default of Black
 
 - repo: https://github.com/pre-commit/mirrors-isort
   rev: v4.3.4

--- a/src/fastaudio/augment/preprocess.py
+++ b/src/fastaudio/augment/preprocess.py
@@ -10,7 +10,7 @@ from ..core.signal import AudioTensor
 mk_class(
     "RemoveType",
     **{o: o.lower() for o in ["Trim", "All", "Split"]},
-    doc="All methods of removing silence as attributes to get tab-completion and typo-proofing",  # noqa: E501
+    doc="All methods of removing silence as attributes to get tab-completion and typo-proofing",
 )
 
 

--- a/src/fastaudio/augment/preprocess.py
+++ b/src/fastaudio/augment/preprocess.py
@@ -1,18 +1,16 @@
-# flake8: noqa
-__all__ = ["RemoveSilence", "Resample"]
-
-from fastai.data.all import *
-from fastai.vision.augment import RandTransform
+import torch
+from fastai.imports import math, np
 from fastcore.transform import Transform
+from fastcore.utils import mk_class, store_attr
 from librosa.effects import split
 from scipy.signal import resample_poly
 
-from ..core.signal import *
+from ..core.signal import AudioTensor
 
 mk_class(
     "RemoveType",
     **{o: o.lower() for o in ["Trim", "All", "Split"]},
-    doc="All methods of removing silence as attributes to get tab-completion and typo-proofing",
+    doc="All methods of removing silence as attributes to get tab-completion and typo-proofing",  # noqa: E501
 )
 
 
@@ -33,7 +31,9 @@ def _merge_splits(splits, pad):
 class RemoveSilence(Transform):
     """Split signal at points of silence greater than 2*pad_ms """
 
-    def __init__(self, remove_type=RemoveType.Trim, threshold=20, pad_ms=20):
+    def __init__(
+        self, remove_type=RemoveType.Trim, threshold=20, pad_ms=20  # noqa: F821
+    ):
         store_attr(self, "remove_type, threshold, pad_ms")
 
     def encodes(self, ai: AudioTensor) -> AudioTensor:
@@ -62,7 +62,8 @@ class RemoveSilence(Transform):
             ]
         else:
             raise ValueError(
-                f"Valid options for silence removal are None, 'split', 'trim', 'all' not '{self.remove_type}'."
+                f"""Valid options for silence removal are
+                None, 'split', 'trim', 'all' not '{self.remove_type}'."""
             )
         ai.data = torch.cat(sig, dim=-1)
         return ai

--- a/src/fastaudio/augment/preprocess.py
+++ b/src/fastaudio/augment/preprocess.py
@@ -1,8 +1,8 @@
 # flake8: noqa
 __all__ = ["RemoveSilence", "Resample"]
 
-from fastai2.data.all import *
-from fastai2.vision.augment import RandTransform
+from fastai.data.all import *
+from fastai.vision.augment import RandTransform
 from fastcore.transform import Transform
 from librosa.effects import split
 from scipy.signal import resample_poly

--- a/src/fastaudio/augment/signal.py
+++ b/src/fastaudio/augment/signal.py
@@ -14,8 +14,8 @@ __all__ = [
 
 
 import colorednoise as cn
-from fastai2.data.all import *
-from fastai2.vision.augment import RandTransform
+from fastai.data.all import *
+from fastai.vision.augment import RandTransform
 from fastcore.transform import Transform
 
 from ..core.signal import *

--- a/src/fastaudio/augment/signal.py
+++ b/src/fastaudio/augment/signal.py
@@ -1,25 +1,12 @@
-# flake8: noqa
-__all__ = [
-    "AudioPadType",
-    "NoiseColor",
-    "CropSignal",
-    "shift_signal",
-    "SignalShifter",
-    "AddNoise",
-    "ChangeVolume",
-    "SignalCutout",
-    "SignalLoss",
-    "DownmixMono",
-]
-
-
 import colorednoise as cn
-from fastai.data.all import *
+import torch
+from fastai.imports import np, random
 from fastai.vision.augment import RandTransform
 from fastcore.transform import Transform
+from fastcore.utils import mk_class, patch, store_attr
 
-from ..core.signal import *
-from ..core.spectrogram import *
+from ..core.signal import AudioTensor
+from ..core.spectrogram import AudioSpectrogram
 
 mk_class(
     "AudioPadType",
@@ -31,7 +18,7 @@ mk_class(
 class CropSignal(Transform):
     """Crops signal to be length specified in ms by duration, padding if needed"""
 
-    def __init__(self, duration, pad_mode=AudioPadType.Zeros):
+    def __init__(self, duration, pad_mode=AudioPadType.Zeros):  # noqa: F821
         store_attr(self, "duration, pad_mode")
 
     def encodes(self, ai: AudioTensor) -> AudioTensor:
@@ -48,7 +35,7 @@ class CropSignal(Transform):
         return ai
 
 
-def _tfm_pad_signal(sig, width, pad_mode=AudioPadType.Zeros):
+def _tfm_pad_signal(sig, width, pad_mode=AudioPadType.Zeros):  # noqa: F821
     """Pad spectrogram to specified width, using specified pad mode"""
     c, x = sig.shape
     pad_m = pad_mode.lower()
@@ -123,7 +110,7 @@ mk_class(
 
 
 class AddNoise(Transform):
-    def __init__(self, noise_level=0.05, color=NoiseColor.White):
+    def __init__(self, noise_level=0.05, color=NoiseColor.White):  # noqa: F821
         store_attr(self, "noise_level, color")
 
     def encodes(self, ai: AudioTensor) -> AudioTensor:

--- a/src/fastaudio/augment/spectrogram.py
+++ b/src/fastaudio/augment/spectrogram.py
@@ -1,14 +1,12 @@
-# flake8: noqa
-__all__ = ["CropTime", "MaskFreq", "MaskTime", "SGRoll", "Delta", "TfmResize"]
-
-
 import librosa
-from fastai.data.all import *
-from fastai.vision.augment import RandTransform
+import torch
+from fastai.imports import partial, random
 from fastcore.transform import Transform
+from fastcore.utils import ifnone, store_attr
+from torch.nn import functional as F
 
-from ..core.all import *
-from .signal import AudioPadType, CropSignal
+from ..core.all import AudioSpectrogram
+from .signal import AudioPadType
 
 
 class CropTime(Transform):

--- a/src/fastaudio/augment/spectrogram.py
+++ b/src/fastaudio/augment/spectrogram.py
@@ -3,8 +3,8 @@ __all__ = ["CropTime", "MaskFreq", "MaskTime", "SGRoll", "Delta", "TfmResize"]
 
 
 import librosa
-from fastai2.data.all import *
-from fastai2.vision.augment import RandTransform
+from fastai.data.all import *
+from fastai.vision.augment import RandTransform
 from fastcore.transform import Transform
 
 from ..core.all import *

--- a/src/fastaudio/core/config.py
+++ b/src/fastaudio/core/config.py
@@ -13,7 +13,7 @@ from dataclasses import make_dataclass
 from inspect import signature
 
 import torchaudio.transforms as transforms
-from fastai2.data.all import *
+from fastai.data.all import *
 from torchaudio import save as save_audio
 
 from ..augment.preprocess import Resample

--- a/src/fastaudio/core/config.py
+++ b/src/fastaudio/core/config.py
@@ -1,25 +1,17 @@
-# flake8: noqa
-__all__ = [
-    "audio_item_tfms",
-    "PreprocessAudio",
-    "preprocess_audio_folder",
-    "AudioBlock",
-    "config_from_func",
-    "AudioConfig",
-]
-
-
 from dataclasses import make_dataclass
 from inspect import signature
 
 import torchaudio.transforms as transforms
-from fastai.data.all import *
+from fastai.data.block import TransformBlock
+from fastai.data.transforms import IntToFloatTensor
+from fastai.imports import Path, partial
+from fastcore.transform import Pipeline
+from fastcore.utils import delegates, ifnone
 from torchaudio import save as save_audio
 
 from ..augment.preprocess import Resample
 from ..augment.signal import CropSignal, DownmixMono
-from .signal import *
-from .spectrogram import *
+from .signal import AudioTensor, get_audio_files
 
 
 def audio_item_tfms(sample_rate=16000, force_mono=True, crop_signal_to=None):
@@ -95,7 +87,8 @@ def config_from_func(func, name, **kwargs):
 
 class AudioConfig:
     # default configurations from the wrapped function
-    # make sure to pass in mel=False as kwarg for non-mel spec, and to_db=False for non db spec
+    # make sure to pass in mel=False as kwarg for non-mel spec
+    # and to_db=False for non db spec
     BasicSpectrogram = config_from_func(
         transforms.Spectrogram, "BasicSpectrogram", mel=False, to_db=True
     )

--- a/src/fastaudio/core/signal.py
+++ b/src/fastaudio/core/signal.py
@@ -1,17 +1,10 @@
-# flake8: noqa
-__all__ = [
-    "audio_extensions",
-    "get_audio_files",
-    "AudioGetter",
-    "tar_extract_at_filename",
-    "AudioTensor",
-    "show_audio_signal",
-    "OpenAudio",
-]
-
 import torchaudio
-from fastai.data.all import *
-from fastai.torch_basics import *
+from fastai.data.external import URLs
+from fastai.data.transforms import Transform, get_files
+from fastai.imports import Path, mimetypes, plt, tarfile
+from fastai.torch_core import TensorBase
+from fastcore.dispatch import retain_type
+from fastcore.utils import add_props, delegates
 from IPython.display import Audio, display
 from librosa.display import waveplot
 
@@ -28,7 +21,8 @@ def get_audio_files(path, recurse=True, folders=None):
 
 
 def AudioGetter(suf="", recurse=True, folders=None):
-    "Create `get_audio_files` partial function that searches path suffix `suf` and passes along `kwargs`, only in `folders`, if specified."
+    """Create `get_audio_files` partial function that searches path suffix `suf`
+    and passes along `kwargs`, only in `folders`, if specified."""
 
     def _inner(o, recurse=recurse, folders=folders):
         return get_audio_files(o / suf, recurse, folders)
@@ -88,7 +82,6 @@ class AudioTensor(TensorBase):
 
 def _get_f(fn):
     def _f(self, *args, **kwargs):
-        cls = self.__class__
         res = getattr(super(TensorBase, self), fn)(*args, **kwargs)
         return retain_type(res, self)
 

--- a/src/fastaudio/core/signal.py
+++ b/src/fastaudio/core/signal.py
@@ -10,8 +10,8 @@ __all__ = [
 ]
 
 import torchaudio
-from fastai2.data.all import *
-from fastai2.torch_basics import *
+from fastai.data.all import *
+from fastai.torch_basics import *
 from IPython.display import Audio, display
 from librosa.display import waveplot
 
@@ -37,9 +37,6 @@ def AudioGetter(suf="", recurse=True, folders=None):
 
 
 URLs.SPEAKERS10 = "http://www.openslr.org/resources/45/ST-AEDS-20180100_1-OS.tgz"
-URLs.SPEAKERS250 = (
-    "https://public-datasets.fra1.digitaloceanspaces.com/250-speakers.tar"
-)
 URLs.ESC50 = "https://github.com/karoldvl/ESC-50/archive/master.zip"
 
 

--- a/src/fastaudio/core/spectrogram.py
+++ b/src/fastaudio/core/spectrogram.py
@@ -15,7 +15,7 @@ from dataclasses import asdict, is_dataclass
 from inspect import signature
 
 import torchaudio
-from fastai2.data.all import *
+from fastai.data.all import *
 from librosa.display import specshow
 
 from .signal import *

--- a/src/fastaudio/core/spectrogram.py
+++ b/src/fastaudio/core/spectrogram.py
@@ -11,9 +11,6 @@ from librosa.display import specshow
 
 from .signal import AudioTensor
 
-# from fastai.data.all import *
-# from .signal import *
-
 
 class AudioSpectrogram(TensorImageBase):
     @classmethod


### PR DESCRIPTION
Now that it's officially launched, the fastai2 package will be deprecated, and fastai updated to 2.0. This PR updates the imports, and also fix the Flake8 problems.