### PR TITLE
Fix build docs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ dev =
     mkautodoc>=0.1
     mkdocs-material>=5.5
     mknotebooks>=0.4
+    nbconvert==5.6.1
     pre_commit>=2.7
     recommonmark>=0.6
     black>=19.10b0


### PR DESCRIPTION
The last merge performed on the repository caused the docs build to fail ([source](https://github.com/fastaudio/fastaudio.github.io/runs/1098688018)). Investigating, I found that in the same day nbconvert, that is used by mknotebooks, updated from 5.6.1 to 6.0 causing the breaking change. This PR pins the dependency to fix this problem.