### PR TITLE
Created a single requirement file for conda and pip

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -6,14 +6,6 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.6
-  - fastai>=2.0
-  - pytorch>=1.6
-  - torchaudio>=0.6
-  - cudatoolkit=10.1
-  - librosa=0.8
-  - fastcore==1.0.8
   - pip>=20.2
-  - IPython>=7.16
   - pip:
-    - colorednoise>=1.1
-    - git+https://github.com/fastaudio/fastaudio.git
+    - -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+colorednoise>=1.1
+fastai>=2.0
+fastcore==1.0.8
+IPython>=7.16
+librosa==0.8
+torchaudio>=0.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,13 +31,6 @@ package_dir =
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 # install_requires = numpy; scipy
-install_requires =
-    fastai>=2.0
-    torchaudio>=0.6
-    librosa==0.8
-    colorednoise>=1.1
-    IPython>=7.16
-    fastcore==1.0.8
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,7 @@ except VersionConflict:
 
 
 if __name__ == "__main__":
-    setup(use_pyscaffold=True)
+    with open('requirements.txt', 'r') as f:
+        REQUIREMENTS = f.read()
+    print(REQUIREMENTS.split('\n'))
+    setup(use_pyscaffold=True, install_requires=REQUIREMENTS.split('\n'))


### PR DESCRIPTION
There were multiple places that requirements were defined

- `environment.yaml`
- `setup.cfg`

These have all been moved now to the `requirements.txt` file that the `environment.yaml` and `setup.cfg` reference in some way. 