### PR TITLE
Fix due to delegates() move in fastcore

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
   - torchaudio>=0.6
   - cudatoolkit=10.1
   - librosa=0.8
-  - fastcore==1.0.8
+  - fastcore>=1.0.19
   - pip>=20.2
   - IPython>=7.16
   - pip:

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
   - torchaudio>=0.6
   - cudatoolkit=10.1
   - librosa=0.8
-  - fastcore>=1.0.19
+  - fastcore==1.0.19
   - pip>=20.2
   - IPython>=7.16
   - pip:

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     librosa==0.8
     colorednoise>=1.1
     IPython>=7.16
-    fastcore>=1.0.19
+    fastcore==1.0.19
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     librosa==0.8
     colorednoise>=1.1
     IPython>=7.16
-    fastcore==1.0.8
+    fastcore>=1.0.19
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/fastaudio/core/config.py
+++ b/src/fastaudio/core/config.py
@@ -6,7 +6,8 @@ from fastai.data.block import TransformBlock
 from fastai.data.transforms import IntToFloatTensor
 from fastai.imports import Path, partial
 from fastcore.transform import Pipeline
-from fastcore.utils import delegates, ifnone
+from fastcore.utils import  ifnone
+from fastcore.meta import delegates
 from torchaudio import save as save_audio
 
 from ..augment.preprocess import Resample

--- a/src/fastaudio/core/signal.py
+++ b/src/fastaudio/core/signal.py
@@ -9,7 +9,8 @@ from fastai.imports import Path, mimetypes, plt, tarfile
 from fastai.torch_core import TensorBase
 from fastai.vision.data import get_grid
 from fastcore.dispatch import retain_type, typedispatch
-from fastcore.utils import delegates, ifnone
+from fastcore.utils import ifnone
+from fastcore.meta import delegates
 from IPython.display import Audio, display
 from librosa.display import waveplot
 

--- a/src/fastaudio/core/spectrogram.py
+++ b/src/fastaudio/core/spectrogram.py
@@ -8,7 +8,8 @@ from fastai.imports import inspect, partial, plt
 from fastai.vision.data import get_grid
 from fastcore.dispatch import typedispatch
 from fastcore.transform import Transform
-from fastcore.utils import delegates, ifnone
+from fastcore.utils import ifnone
+from fastcore.meta import delegates
 from librosa.display import specshow
 from torch import nn
 


### PR DESCRIPTION
With [this commit of **fastcore**](https://github.com/fastai/fastcore/commit/3209aee4c46d179c59d848b0246a0a4e81a81fa4), `delegates()` was moved into `meta.py`. This PR adapts the `fastaudio` code to correspond to the introduced change. 