### PR TITLE
Drop conda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In the future we will offer conda and pip installs, but as the code is rapidly c
 
 ---
 
-Install method using pip:
+Install using pip:
 
 ```
 pip install git+https://github.com/fastaudio/fastaudio.git

--- a/README.md
+++ b/README.md
@@ -12,17 +12,7 @@ In the future we will offer conda and pip installs, but as the code is rapidly c
 
 ---
 
-To install using anaconda:
-
-```
-wget https://raw.githubusercontent.com/fastaudio/fastaudio/master/environment.yaml
-conda env create -f environment.yaml
-```
-Then, a new environment with the name `fastaudio` will be created and you can access it by running `conda activate fastaudio`
-
----
-
-Alternative install method using pip:
+Install method using pip:
 
 ```
 pip install git+https://github.com/fastaudio/fastaudio.git


### PR DESCRIPTION
In #54 the `environment.yml` file was destroyed and the conda instruction of creating an environment from yml file is no loger valid. 