### PR TITLE
chore: Consolidate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@
 
 ## Install
 
-In the future we will offer conda and pip installs, but as the code is rapidly changing, we recommend that only those interested in contributing and experimenting install for now. Everyone else should use [Fastai audio v1](https://github.com/mogwai/fastai_audio)
-
----
 
 Install using pip:
 
@@ -43,22 +40,22 @@ pre-commit install
 ```
 
 # Testing
-To run the tests and verify everythig is working, you'll need to create an environment like above:
+To run the tests and verify everythig is working, run the following command from the `fastaudio/` folder (only applicable after doing the editable install steps):
 
 ```
-git clone git@github.com:fastaudio/fastaudio
-pip install .[dev,testing]
 pytest
 ```
 
+This will run all of the test suit, reporting if there are any errors and also giving a code coverage report. Adittionally, there are extra checks that `pre-commit` run automatically every commit to verify the formatting and flake8 violations. If you want to run those manually, the command is `pre-commit run`
+
 # Contributing to the library
 
-We are looking for contributors of all skill levels. If you don't have time to contribute, please at least reach out and give us some feedback on the library.
+We are looking for contributors of all skill levels. If you don't have time to contribute, please at least reach out and give us some feedback on the library by posting in the [v2 audio thread](https://forums.fast.ai/t/fastai-v2-audio/53535).
 
 Make sure that you have activated the environment that you used `pre-commit install` in so that pre-commit knows where to run the git hooks.
 
 ### How to contribute
-Create issues, write documentation, suggest/add features, submit PRs. We are open to anything.
+Create issues, write documentation, suggest/add features, submit PRs. We are open to anything. A good first step would be posting in the [v2 audio thread](https://forums.fast.ai/t/fastai-v2-audio/53535) introducing yourself.
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This will run all of the test suit, reporting if there are any errors and also g
 
 # Contributing to the library
 
-We are looking for contributors of all skill levels. If you don't have time to contribute, please at least reach out and give us some feedback on the library by posting in the [v2 audio thread](https://forums.fast.ai/t/fastai-v2-audio/53535).
+We are looking for contributors of all skill levels. If you don't have time to contribute, please at least reach out and give us some feedback on the library.
 
 Make sure that you have activated the environment that you used `pre-commit install` in so that pre-commit knows where to run the git hooks.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Quick Start
 
-[Google Colab Notebook](https://colab.research.google.com/github/fastaudio/fastaudio/blob/master/docs/Training_tutorial.ipynb)
+[Google Colab Notebook](https://colab.research.google.com/github/fastaudio/fastaudio/blob/master/docs//ESC50: Environmental Sound Classification.ipynb)
 
 [Zachary Mueller's class](https://youtu.be/0IQYJNkAI3k?t=1665)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pre-commit install
 ```
 
 # Testing
-To run the tests and verify everythig is working, run the following command from the `fastaudio/` folder (only applicable after doing the editable install steps):
+To run the tests and verify everything is working, run the following command from the `fastaudio/` folder (only applicable after doing the editable install steps):
 
 ```
 pytest

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 # Fastaudio
 > An audio module for fastai v2. We want to help you build audio machine learning applications while minimizing the need for audio domain expertise. Currently under development.
 
+# Quick Start
+
+[Google Colab Notebook](https://colab.research.google.com/github/fastaudio/fastaudio/blob/master/docs/Training_tutorial.ipynb)
+
+[Zachary Mueller's class](https://youtu.be/0IQYJNkAI3k?t=1665)
+
 ## Install
 
 In the future we will offer conda and pip installs, but as the code is rapidly changing, we recommend that only those interested in contributing and experimenting install for now. Everyone else should use [Fastai audio v1](https://github.com/mogwai/fastai_audio)

--- a/docs/Learning resources.md
+++ b/docs/Learning resources.md
@@ -1,0 +1,11 @@
+This section presents a list of learning resources to help understanding the foundations of deep learning with audio.
+
+## Signal Processing Basics
+
+- [Compact primer on digital signal processing](https://jackschaedler.github.io/circles-sines-signals/index.html)
+- [What is a fourier transform? by 3Blue1Brown](https://youtu.be/spUNpyF58BY)
+- [How to normalize spectrograms](https://enzokro.dev/spectrogram_normalizations/2020/09/10/Normalizing-spectrograms-for-deep-learning.html)
+
+## Audio generation
+
+- [Generating music in the waveform domain](https://benanne.github.io/2020/03/24/audio-generation.html)

--- a/docs/Learning resources.md
+++ b/docs/Learning resources.md
@@ -5,6 +5,7 @@ This section presents a list of learning resources to help understanding the fou
 - [Compact primer on digital signal processing](https://jackschaedler.github.io/circles-sines-signals/index.html)
 - [What is a fourier transform? by 3Blue1Brown](https://youtu.be/spUNpyF58BY)
 - [How to normalize spectrograms](https://enzokro.dev/spectrogram_normalizations/2020/09/10/Normalizing-spectrograms-for-deep-learning.html)
+- [What is a Spectrogram](https://www.youtube.com/watch?v=_FatxGN3vAM)
 - [Audio Signal Processing for Machine Learning](https://www.youtube.com/playlist?list=PL-wATfeyAMNqIee7cH3q1bh4QJFAaeNv0)
 
 ## Audio generation

--- a/docs/Learning resources.md
+++ b/docs/Learning resources.md
@@ -5,6 +5,7 @@ This section presents a list of learning resources to help understanding the fou
 - [Compact primer on digital signal processing](https://jackschaedler.github.io/circles-sines-signals/index.html)
 - [What is a fourier transform? by 3Blue1Brown](https://youtu.be/spUNpyF58BY)
 - [How to normalize spectrograms](https://enzokro.dev/spectrogram_normalizations/2020/09/10/Normalizing-spectrograms-for-deep-learning.html)
+- [Audio Signal Processing for Machine Learning](https://www.youtube.com/playlist?list=PL-wATfeyAMNqIee7cH3q1bh4QJFAaeNv0)
 
 ## Audio generation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,1 @@
-# Fastaudio
-
-> An audio module for fastai v2. We want to help you build audio machine learning applications while minimizing the need for audio domain expertise. Currently under development.
-
-
-# Quick Start
-
-[Google Colab Notebook](https://colab.research.google.com/github/fastaudio/fastaudio/blob/master/docs/Training_tutorial.ipynb)
-
-[Zachary Mueller's class](https://youtu.be/0IQYJNkAI3k?t=1665)
+../README.md


### PR DESCRIPTION
Changes:
* Repository readme.md and docs index page now point to the same file, so they are equal
* The learning resources present on the [wiki](https://github.com/fastaudio/fastaudio/wiki/Learning-resources) have been moved inside the docs instead
* Small changes to the wording in the README and fix broken colab link