### PR TITLE
Reduce IPython requirement for Kaggle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     torchaudio>=0.6
     librosa==0.8
     colorednoise>=1.1
-    IPython>=7.16
+    IPython>=7.13
     fastcore==1.3.4
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov


### PR DESCRIPTION
People are having trouble installing fastaudio on Kaggle. One problem seems to be that Kaggle has IPython 7.13, but fastaudio requires 7.16.

This seems to be when the requirement was introduced (@mogwai):

https://github.com/fastaudio/fastaudio/commit/e01b4d4ac1430e1e23d0c06cfd6c28e0b96e5d99#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52R34

Are there any issues with downgrading?