### PR TITLE
fix: Removing version.txt from release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,11 +4,6 @@
     ],
     "plugins": [
         "@semantic-release/commit-analyzer",
-        ["@semantic-release/exec",
-          {
-            "verifyReleaseCmd": "echo ${nextRelease.version} > version.txt"
-          }
-        ],
         "@semantic-release/release-notes-generator",
         "@semantic-release/github"
     ]


### PR DESCRIPTION
Removing the generation of the version.txt as we don't need it from `.releaserc.json`