### PR TITLE
change linux backend to fix mp3 load bug

### DIFF
--- a/src/fastaudio/__init__.py
+++ b/src/fastaudio/__init__.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 from pkg_resources import DistributionNotFound, get_distribution
 
+import os
 import torchaudio
 
 torchaudio.USE_SOUNDFILE_LEGACY_INTERFACE = False
-torchaudio.set_audio_backend("soundfile")
+# soundfile is torchaudio backend for windows, all other os use sox_io
+backend = "soundfile" if os.name == "nt" else "sox_io"
+torchaudio.set_audio_backend(backend)
 try:
     # Change here if project is renamed and does not equal the package name
     dist_name = __name__


### PR DESCRIPTION
-Changes audio backend to sox_io for linux/mac
-Keeps audio backend as soundfile for windows
-Changes made based on [recommendations in torchaudio docs](https://pytorch.org/audio/stable/backend.html#backend) (image below)

![image](https://user-images.githubusercontent.com/47190785/101996369-c820ee00-3c9f-11eb-8880-1ce7e92d4f59.png)
