### PR TITLE
fix: Upgrade to latest fastai version

### DIFF
--- a/docs/ESC50: Environmental Sound Classification.ipynb
+++ b/docs/ESC50: Environmental Sound Classification.ipynb
@@ -352,7 +352,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While creating the learner, we need to pass a special cnn_config to indicate that our input spectrograms only have one channel. Besides that, it's the usual vision learner."
+    "While creating the learner, we need to indicate that our input spectrograms only have one channel. Besides that, it's the usual vision learner."
    ]
   },
   {
@@ -363,7 +363,7 @@
    "source": [
     "learn = cnn_learner(dbunch, \n",
     "            resnet18,\n",
-    "            config=cnn_config(n_in=1), #<- Only audio specific modification here\n",
+    "            n_in=1,  # <- This is the only audio specific modification here\n",
     "            loss_func=CrossEntropyLossFlat(),\n",
     "            metrics=[accuracy])"
    ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,12 +32,12 @@ setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 # install_requires = numpy; scipy
 install_requires =
-    fastai==2.1.5
+    fastai==2.1.9
     torchaudio>=0.6
     librosa==0.8
     colorednoise>=1.1
     IPython>=7.13
-    fastcore==1.3.4
+    fastcore==1.3.12
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
@@ -58,6 +58,7 @@ testing =
     pytest-cov>=2.10
     papermill
     jupyter
+    seaborn
 
 #TODO: mknotebooks is fixed at 0.5 until https://github.com/greenape/mknotebooks/issues/90
 # is fixed. When upgrading to 0.6+, remove the nbconvert==5.6.1 and markdown==3.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,6 @@ testing =
     pytest-cov>=2.10
     papermill
     jupyter
-    seaborn
 
 #TODO: mknotebooks is fixed at 0.5 until https://github.com/greenape/mknotebooks/issues/90
 # is fixed. When upgrading to 0.6+, remove the nbconvert==5.6.1 and markdown==3.2.1


### PR DESCRIPTION
update fastai and fastcore
add seaborn test dependency (`test_dataset.py` was failing without this)
changes in ESC50 notebook because of this commit https://github.com/fastai/fastai/commit/eaa588fdc1efdfdd4a3c1dcae1895add10f223a7 