### PR TITLE
GPU-Compatible Batch Versions of Existing Transforms

### DIFF
--- a/src/fastaudio/augment/spectrogram.py
+++ b/src/fastaudio/augment/spectrogram.py
@@ -206,12 +206,7 @@ class Delta(SpectrogramTransform):
 
 
 class DeltaGPU(SpectrogramTransform):
-    """Adds extra channels with delta (orders 1 and 2) to spectrogram.
-
-    Note that the input(s) must only have one channel. Passing a spectrogram
-    with multiple channels already may raise an error.
-
-    """
+    """Adds extra channels with delta (orders 1 and 2) to spectrogram."""
 
     def __init__(self, width=9, mode="replicate"):
         self.width = width

--- a/src/fastaudio/augment/spectrogram.py
+++ b/src/fastaudio/augment/spectrogram.py
@@ -117,9 +117,7 @@ class MaskTime(SpectrogramTransform):
 class _MaskAxisGPU(SpectrogramTransform):
     """Base class for GPU-based SpecAugment masking transforms."""
 
-    def __init__(
-        self, axis, num_masks, min_size, max_size, mask_val
-    ):
+    def __init__(self, axis, num_masks, min_size, max_size, mask_val):
         if axis not in [2, 3]:
             raise ValueError("Can only mask the time or frequency axis (2 or 3)")
         self.num_masks = num_masks

--- a/src/fastaudio/augment/spectrogram.py
+++ b/src/fastaudio/augment/spectrogram.py
@@ -7,6 +7,7 @@ from fastcore.utils import ifnone
 from torch.nn import functional as F
 
 from ..core.spectrogram import AudioSpectrogram, AudioTensor
+from ..util import auto_batch
 from .signal import AudioPadType
 
 
@@ -169,4 +170,22 @@ class TfmResize(SpectrogramTransform):
         sg.data = F.interpolate(
             sg.unsqueeze(0), size=self.size, mode=self.interp_mode, align_corners=False
         ).squeeze(0)
+        return sg
+
+
+class TfmResizeGPU(SpectrogramTransform):
+    """Resize the spectrogram using interpolation."""
+
+    def __init__(self, size, interp_mode="bilinear"):
+        if isinstance(size, int):
+            self.size = (size, size)
+        else:
+            self.size = size
+        self.interp_mode = interp_mode
+
+    @auto_batch(3)
+    def encodes(self, sg: AudioSpectrogram):
+        sg.data = F.interpolate(
+            sg, size=self.size, mode=self.interp_mode, align_corners=False
+        )
         return sg

--- a/src/fastaudio/functional.py
+++ b/src/fastaudio/functional.py
@@ -27,9 +27,7 @@ def region_mask(n, min_mask_size, max_mask_size, maskable_length, device=None):
     return (mask_starts <= indexes) & (indexes < mask_ends)
 
 
-def mask_along_axis_(
-    specgrams, num_masks, min_size, max_size, mask_val=None, axis=2
-):
+def mask_along_axis_(specgrams, num_masks, min_size, max_size, mask_val=None, axis=2):
     """Apply SpecAugment masks emitting from one axis.
 
     ``specgrams`` should be a tensor of shape (batch, channels, freq, time).
@@ -54,13 +52,17 @@ def mask_along_axis_(
     else:
         # To create multiple masks per spectrogram, create a larger batch,
         # reshape, then merge.
-        masks = region_mask(
-            num_masks * n,
-            min_size,
-            max_size,
-            a,
-            device=device,
-        ).view(num_masks, n, a).amax(dim=0)
+        masks = (
+            region_mask(
+                num_masks * n,
+                min_size,
+                max_size,
+                a,
+                device=device,
+            )
+            .view(num_masks, n, a)
+            .amax(dim=0)
+        )
     # Expand so it can be broadcasted.
     masks = masks.view(n, 1, 1, a)
 

--- a/src/fastaudio/functional.py
+++ b/src/fastaudio/functional.py
@@ -1,0 +1,12 @@
+import torch
+
+
+def random_mask(shape, p, device=None):
+    """Create a bool tensor with items set to 1 with probability ``p``.
+
+    (Items are set individually.)
+
+    ``p`` may be a float or a tensor broadcastable to ``shape``.
+
+    """
+    return torch.rand(shape, device=device) <= p

--- a/src/fastaudio/functional.py
+++ b/src/fastaudio/functional.py
@@ -244,8 +244,8 @@ def add_noise_(x: Tensor, color: NoiseColor, min_level: float, max_level: float,
         # Note that noise is scaled per-item, not per-channel. This means loud
         # channels will dwarf quiet channels.
         random_mask([n], p, device=x.device)
-        * (x.reshape(n, -1).std(dim=1) * (max_level - min_level) + min_level)
-        * torch.rand([n], device=x.device)
+        * x.reshape(n, -1).std(dim=1)
+        * (torch.rand([n], device=x.device) * (max_level - min_level) + min_level)
     ).reshape([n] + [1] * (x.dim() - 1))
     x += noise_levels * (colored_noise(x.shape, exponent=color, device=x.device) - 0.5)
     return x

--- a/src/fastaudio/functional.py
+++ b/src/fastaudio/functional.py
@@ -1,5 +1,9 @@
 import torch
 
+# Must be imported explicitly to override the top-level `torch.fft` function
+import torch.fft
+from torch import Tensor
+
 
 def region_mask(n, min_mask_size, max_mask_size, maskable_length, device=None):
     """Create a vector of ``n`` random region masks.
@@ -32,3 +36,150 @@ def random_mask(shape, p, device=None):
 
     """
     return torch.rand(shape, device=device) <= p
+
+
+# TODO: Remove this & all uses, replace with torch.fft.rfftfreq
+def _rfftfreq(n, d=1.0, device=None):
+    """Get the sample frequencies for a discrete fourier transform."""
+    val = 1.0 / (n * d)
+    results = torch.arange(0, n // 2 + 1, device=device, dtype=int)
+    return results * val
+
+
+class NoiseColor:
+    """Exponent beta values for named noise colors (see `colored_noise`)."""
+
+    Violet = -2
+    Blue = -1
+    White = 0
+    Pink = 1
+    Brown = 2
+
+    @staticmethod
+    def valid(value: int) -> bool:
+        """Is ``value`` a valid color for noise?"""
+        return value in [*range(-2, 3)]
+
+
+def colored_noise(shape, exponent, fmin=0, device=None):
+    """Gaussian (1/f)**beta noise.
+
+    Based on the algorithm in:
+    Timmer, J. and Koenig, M.:
+    On generating power law noise.
+    Astron. Astrophys. 300, 707-710 (1995)
+    Normalised to unit variance
+
+    Ported to PyTorch from Felix Patzelt's numpy implementation, MIT Licensed.
+    https://github.com/felixpatzelt/colorednoise/blob/acc9ec529b181dec2bd7fb914f87f0a62a0553d3/colorednoise.py
+
+    Parameters:
+    -----------
+
+    exponent : float
+        The power-spectrum of the generated noise is proportional to
+        S(f) = (1 / f)**beta
+        flicker / pink noise:   exponent beta = 1
+        brown noise:            exponent beta = 2
+        Furthermore, the autocorrelation decays proportional to lag**-gamma
+        with gamma = 1 - beta for 0 < beta < 1.
+        There may be finite-size issues for beta close to one.
+
+    shape : int or iterable
+        The output has the given shape, and the desired power spectrum in
+        the last coordinate. That is, the last dimension is taken as time,
+        and all other components are independent.
+
+    fmin : float, optional
+        Low-frequency cutoff.
+        Default: 0 corresponds to original paper. It is not actually
+        zero, but 1/samples.
+
+    Returns
+    -------
+
+    out : array
+        The samples.
+
+    Examples:
+    ---------
+
+    # generate 1/f noise == pink noise == flicker noise
+    >>> y = colored_noise([1], 5)
+
+    """
+    # Use `is` to allow for tensor exponents
+    if exponent is NoiseColor.White:
+        # White noise is simple - use a faster method.
+        return torch.randn(shape)
+
+    # The number of samples in each time series
+    nsamples = shape[-1]
+
+    # Calculate Frequencies (we asume a sample rate of one)
+    # Use fft functions for real output (-> hermitian spectrum)
+    # FIXME: torch.fft is missing this for some reason
+    # f = torch.fft.rfftfreq(nsamples)
+    f = _rfftfreq(nsamples, device=device)
+
+    # Build scaling factors for all frequencies
+    s_scale = f
+    fmin = max(fmin, 1.0 / nsamples)  # Low frequency cutoff
+    ix = (s_scale < fmin).sum()  # Index of the cutoff
+    if ix and ix < len(s_scale):
+        s_scale[:ix] = s_scale[ix]
+    s_scale = s_scale ** (-exponent / 2.0)
+
+    # Calculate theoretical output standard deviation from scaling
+    w = s_scale[1:].clone()
+    w[-1] *= (1 + (nsamples % 2)) / 2.0  # correct f = +-0.5
+    sigma = 2 * (w ** 2).sum().sqrt() / nsamples
+
+    # Adjust size to generate one Fourier component per frequency
+    new_shape = (*shape[:-1], f.size(0))
+    # Original numpy imp
+    # shape[-1] = f.size(0)
+
+    # Add empty dimension(s) to broadcast s_scale along last
+    # dimension of generated random power + phase (below)
+    dims_to_add = len(new_shape) - 1
+    s_scale = s_scale[[None] * dims_to_add + [Ellipsis]]
+
+    # Generate scaled random power + phase
+    sr = torch.randn(new_shape, device=device) * s_scale
+    si = torch.randn(new_shape, device=device) * s_scale
+
+    # If the signal length is even, frequencies +/- 0.5 are equal
+    # so the coefficient must be real.
+    if not (nsamples % 2):
+        si[..., -1] = 0
+
+    # Regardless of signal length, the DC component must be real
+    si[..., 0] = 0
+
+    # Combine power + corrected phase to Fourier components
+    s = sr + 1j * si
+
+    # Transform to real time series & scale to unit variance
+    y = torch.fft.irfft(s, n=nsamples, dim=-1) / sigma
+
+    return y
+
+
+def add_noise_(x: Tensor, color: NoiseColor, min_level: float, max_level: float, p=1.0):
+    """Add colored noise to a batch of tensors, randomising per-item.
+
+    Levels are relative to the standard deviation of each item.
+
+    """
+    n = x.size(0)
+
+    noise_levels = (
+        # Note that noise is scaled per-item, not per-channel. This means loud
+        # channels will dwarf quiet channels.
+        random_mask([n], p, device=x.device)
+        * (x.reshape(n, -1).std(dim=1) * (max_level - min_level) + min_level)
+        * torch.rand([n], device=x.device)
+    ).reshape([n] + [1] * (x.dim() - 1))
+    x += noise_levels * (colored_noise(x.shape, exponent=color, device=x.device) - 0.5)
+    return x

--- a/src/fastaudio/functional.py
+++ b/src/fastaudio/functional.py
@@ -1,6 +1,28 @@
 import torch
 
 
+def region_mask(n, min_mask_size, max_mask_size, maskable_length, device=None):
+    """Create a vector of ``n`` random region masks.
+
+    Masks are returned in a vector with shape `(n, maskable_length)`.
+
+    The mask vectors are boolean vectors of ``maskable_length`` with a
+    continuous region of 1s between ``min_mask_size`` and ``max_mask_size``
+    (inclusive).
+
+    """
+    # Generate the start & end positions for each mask, then compare these to
+    # absolute indices to create the actual mask vectors.
+    mask_sizes = (
+        torch.rand([n, 1], device=device) * (max_mask_size - min_mask_size)
+        + min_mask_size
+    )
+    mask_starts = torch.rand([n, 1], device=device) * (maskable_length - mask_sizes)
+    mask_ends = mask_starts + mask_sizes
+    indexes = torch.arange(0, maskable_length, device=device)
+    return (mask_starts <= indexes) & (indexes < mask_ends)
+
+
 def random_mask(shape, p, device=None):
     """Create a bool tensor with items set to 1 with probability ``p``.
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,0 +1,56 @@
+import torch
+from fastai.data.all import test_eq as _test_eq
+from unittest.mock import patch
+
+from fastaudio.functional import region_mask
+
+
+class TestCreateRegionMask:
+
+    def test_shape(self):
+        _test_eq(region_mask(1, 5, 7, 10).shape, (1, 10))
+        _test_eq(region_mask(2, 3, 7, 12).shape, (2, 12))
+        _test_eq(region_mask(4, 0, 3, 3).shape, (4, 3))
+
+    def test_max(self):
+        # Test max size
+        with patch(
+            "torch.rand",
+            side_effect=[
+                torch.Tensor([[[[1.0]]]]),
+                torch.Tensor([[[[0.0]]]]),
+            ],
+        ):
+            _test_eq(
+                region_mask(1, 4, 6, 10),
+                torch.BoolTensor([[[[1] * 6 + [0] * 4]]]),
+            )
+
+    def test_min(self):
+        # Test min size
+        with patch(
+            "torch.rand",
+            side_effect=[
+                torch.Tensor([0.0]),
+                # Test start middle start here too
+                torch.Tensor([0.5]),
+            ],
+        ):
+            _test_eq(
+                region_mask(1, 4, 6, 10),
+                torch.BoolTensor([0] * 3 + [1] * 4 + [0] * 3),
+            )
+
+    def test_multiple_masks(self):
+        # Test multiple masks
+        with patch(
+            "torch.rand",
+            side_effect=[
+                torch.Tensor([[1.0], [0.0]]),
+                torch.Tensor([[0.0], [0.5]]),
+            ],
+        ):
+            _test_eq(
+                region_mask(2, 4, 6, 10),
+                torch.BoolTensor([[1] * 6 + [0] * 4, [0] * 3 + [1] * 4 + [0] * 3]),
+            )

--- a/tests/test_signal_augment.py
+++ b/tests/test_signal_augment.py
@@ -18,7 +18,7 @@ from fastaudio.all import (
     RemoveType,
     Resample,
     ResizeSignal,
-    SignalLoss,
+    SignalLossGPU,
     SignalCutoutGPU,
     SignalShifter
 )
@@ -230,7 +230,7 @@ def test_change_volume(audio):
 
 
 def test_signal_loss(audio):
-    signalloss = SignalLoss(1)
+    signalloss = SignalLossGPU(1)
     inp, out = apply_transform(signalloss, audio)
     _test_ne(inp.data, out.data)
 

--- a/tests/test_signal_augment.py
+++ b/tests/test_signal_augment.py
@@ -1,7 +1,6 @@
-import random
-
 import pytest
 
+import random
 import torch
 from fastai.data.all import test_close as _test_close
 from fastai.data.all import test_eq as _test_eq
@@ -18,9 +17,9 @@ from fastaudio.all import (
     RemoveType,
     Resample,
     ResizeSignal,
-    SignalLossGPU,
     SignalCutoutGPU,
-    SignalShifter
+    SignalLossGPU,
+    SignalShifter,
 )
 from fastaudio.augment.signal import _shift
 from fastaudio.util import apply_transform, test_audio_tensor

--- a/tests/test_signal_augment.py
+++ b/tests/test_signal_augment.py
@@ -8,7 +8,7 @@ from fastai.data.all import test_eq as _test_eq
 from fastai.data.all import test_ne as _test_ne
 
 from fastaudio.all import (
-    AddNoise,
+    AddNoiseGPU,
     AudioPadType,
     AudioTensor,
     ChangeVolumeGPU,
@@ -208,17 +208,21 @@ def test_down_mix_mono(audio):
 
 def test_noise_fail_bad_color(audio):
     with pytest.raises(ValueError):
-        AddNoise(audio, color=5)
+        AddNoiseGPU(audio, color=5)
+
+    with pytest.raises(ValueError):
+        AddNoiseGPU(audio, color=-3)
 
 
 def test_noise_white(audio):
-    addnoise = AddNoise(color=NoiseColor.White)
+    addnoise = AddNoiseGPU(color=NoiseColor.White, p=1.0, min_level=0.1, max_level=0.2)
     inp, out = apply_transform(addnoise, audio)
     _test_ne(inp.data, out.data)
 
 
 def test_noise_non_white(audio):
-    addnoise = AddNoise(color=NoiseColor.Pink)
+    # White noise uses a different method to other noises, so test both.
+    addnoise = AddNoiseGPU(color=NoiseColor.Pink, p=1.0, min_level=0.1, max_level=0.2)
     inp, out = apply_transform(addnoise, audio)
     _test_ne(inp.data, out.data)
 

--- a/tests/test_signal_augment.py
+++ b/tests/test_signal_augment.py
@@ -11,7 +11,7 @@ from fastaudio.all import (
     AddNoise,
     AudioPadType,
     AudioTensor,
-    ChangeVolume,
+    ChangeVolumeGPU,
     DownmixMono,
     NoiseColor,
     RemoveSilence,
@@ -224,7 +224,7 @@ def test_noise_non_white(audio):
 
 
 def test_change_volume(audio):
-    changevol = ChangeVolume(1)
+    changevol = ChangeVolumeGPU(1)
     inp, out = apply_transform(changevol, audio)
     _test_ne(inp.data, out.data)
 

--- a/tests/test_spectrogram_augment.py
+++ b/tests/test_spectrogram_augment.py
@@ -220,7 +220,7 @@ def test_delta_channels():
     _test_eq(out.nchannels, inp.nchannels * 3)
     _test_eq(out.shape[-2:], inp.shape[-2:])
     for i1, i2 in [(0, 2), (1, 3), (0, 4), (1, 5), (2, 4), (3, 5)]:
-        _test_ne(out[i1], out[i2])
+        assert not torch.allclose(out[i1], out[i2])
 
 
 def test_signal_shift_on_sg():

--- a/tests/test_spectrogram_augment.py
+++ b/tests/test_spectrogram_augment.py
@@ -1,7 +1,6 @@
-import random
-
 import pytest
 
+import random
 import torch
 from fastai.data.all import test_close as _test_close
 from fastai.data.all import test_eq as _test_eq

--- a/tests/test_spectrogram_augment.py
+++ b/tests/test_spectrogram_augment.py
@@ -7,15 +7,17 @@ from fastai.data.all import test_close as _test_close
 from fastai.data.all import test_eq as _test_eq
 from fastai.data.all import test_fail as _test_fail
 from fastai.data.all import test_ne as _test_ne
+from unittest.mock import patch
 
 from fastaudio.all import (
     AudioConfig,
     AudioPadType,
+    AudioSpectrogram,
     AudioToSpec,
     CropTime,
-    MaskFreq,
-    MaskTime,
     DeltaGPU,
+    MaskFreqGPU,
+    MaskTimeGPU,
     OpenAudio,
     Pipeline,
     ResizeSignal,
@@ -89,32 +91,111 @@ def test_fail_bad_pad():
 
 
 def test_mask_freq():
-    # create a random frequency mask and test that it is being correctly applied
-    size, start, val = [random.randint(1, 50) for i in range(3)]
-    freq_mask_test = MaskFreq(size=size, start=start, val=val)
-    sg_orig = test_audio_tensor()
-    a2s = AudioToSpec.from_cfg(AudioConfig.Voice())
-    sg = a2s(sg_orig)
+    c, f, t = 2, 120, 80
 
-    inp, out = apply_transform(freq_mask_test, sg)
-    _test_eq(
-        out[:, start : start + size, :],
-        val * torch.ones_like(inp)[:, start : start + size, :],
+    # Create a random frequency mask and test that it is being correctly applied
+    min_size = 5
+    max_size = 7
+
+    sg = AudioSpectrogram(torch.rand([c, f, t]))
+    val = 10  # Use a value not in the original spectrogram
+    gradient_sg = AudioSpectrogram(
+        torch.linspace(0, 1, f).view(1, f, 1).repeat([c, 1, t])
     )
+    ones = torch.ones_like(sg)
+
+    # Test patching with mean
+    with patch(
+        "fastaudio.functional.region_mask",
+        side_effect=[
+            torch.BoolTensor([[1] * 10 + [0] * (f - 10)]),
+        ],
+    ):
+        mask_with_mean = MaskFreqGPU(
+            min_size=min_size, max_size=max_size, mask_val=None
+        )
+        # Use a gradient so we can be sure the mean will never show up outside the mask
+        inp, out = apply_transform(mask_with_mean, gradient_sg)
+        channelwise_mean = inp[:, :10, :].mean(dim=(-2, -1)).reshape(-1, 1, 1)
+        _test_eq(out[:, :10, :], channelwise_mean * ones[:, :10, :])
+        assert not (out[:, 10:, :] == channelwise_mean).any(), out == channelwise_mean
+
+    # Test multiple masks (and patching with value)
+    with patch(
+        "fastaudio.functional.region_mask",
+        side_effect=[
+            torch.BoolTensor([[1] * 10 + [0] * (f - 10), [0] * (f - 10) + [1] * 10]),
+        ],
+    ):
+        mask_with_val = MaskFreqGPU(
+            min_size=min_size, num_masks=2, max_size=max_size, mask_val=val
+        )
+        inp, out = apply_transform(mask_with_val, sg)
+        _test_eq(
+            out[:, :10, :],
+            val * ones[:, :10, :],
+        )
+        _test_eq(
+            out[:, f - 10 :, :],
+            val * ones[:, f - 10 :, :],
+        )
+        matches = out[:, 10 : f - 10] == val
+        assert not matches.any(), matches
 
 
-def test_mask_freq():
-    # create a random time mask and test that it is being correctly applied
-    size, start, val = [random.randint(1, 50) for i in range(3)]
-    time_mask_test = MaskTime(size=size, start=start, val=val)
-    audio = test_audio_tensor()
-    a2s = AudioToSpec.from_cfg(AudioConfig.Voice())
-    sg = a2s(audio)
-    inp, out = apply_transform(time_mask_test, sg)
-    _test_eq(
-        out[:, :, start : start + size],
-        val * torch.ones_like(inp)[:, :, start : start + size],
+def test_mask_time():
+    c, f, t = 2, 120, 80
+
+    min_size = 5
+    max_size = 7
+
+    sg = AudioSpectrogram(torch.rand([c, f, t]))
+    val = 10  # Use a value not in the original spectrogram
+    gradient_sg = AudioSpectrogram(
+        torch.linspace(0, 1, t).view(1, 1, t).repeat([c, f, 1])
     )
+    ones = torch.ones_like(sg)
+
+    # Test patching with mean
+    with patch(
+        "fastaudio.functional.region_mask",
+        side_effect=[
+            torch.BoolTensor([[1] * 10 + [0] * (t - 10)]),
+        ],
+    ):
+        mask_with_mean = MaskTimeGPU(
+            min_size=min_size, max_size=max_size, mask_val=None
+        )
+        # Use a gradient so we can be sure the mean will never show up outside the mask
+        inp, out = apply_transform(mask_with_mean, gradient_sg)
+        channelwise_mean = inp[..., :10].mean(dim=(-2, -1)).reshape(-1, 1, 1)
+        _test_close(
+            out[..., :10],
+            channelwise_mean * ones[..., :10],
+        )
+        assert not (out[..., 10:] == channelwise_mean).any(), out == channelwise_mean
+
+    # Test multiple masks (and patching with value)
+    with patch(
+        "fastaudio.functional.region_mask",
+        side_effect=[
+            torch.BoolTensor([[1] * 10 + [0] * (t - 10), [0] * (t - 10) + [1] * 10]),
+        ],
+    ):
+        mask_with_val = MaskTimeGPU(
+            min_size=min_size, num_masks=2, max_size=max_size, mask_val=val
+        )
+        inp, out = apply_transform(mask_with_val, sg)
+        _test_eq(
+            out[..., :10],
+            val * ones[..., :10],
+        )
+        _test_eq(
+            out[..., t - 10 :],
+            val * ones[..., t - 10 :],
+        )
+        matches = out[..., 10 : t - 10] == val
+        assert not matches.any(), matches
 
 
 def test_resize_int():

--- a/tests/test_spectrogram_augment.py
+++ b/tests/test_spectrogram_augment.py
@@ -218,8 +218,9 @@ def test_delta_channels():
     inp, out = apply_transform(delta, sg)
 
     _test_eq(out.nchannels, inp.nchannels * 3)
-    _test_eq(out.shape[1:], inp.shape[1:])
-    _test_ne(out[0], out[1])
+    _test_eq(out.shape[-2:], inp.shape[-2:])
+    for i1, i2 in [(0, 2), (1, 3), (0, 4), (1, 5), (2, 4), (3, 5)]:
+        _test_ne(out[i1], out[i2])
 
 
 def test_signal_shift_on_sg():

--- a/tests/test_spectrogram_augment.py
+++ b/tests/test_spectrogram_augment.py
@@ -22,7 +22,7 @@ from fastaudio.all import (
     SGRoll,
     SignalShifter,
     SpectrogramTransformer,
-    TfmResize
+    TfmResizeGPU,
 )
 from fastaudio.util import apply_transform, test_audio_tensor
 
@@ -120,7 +120,7 @@ def test_mask_freq():
 def test_resize_int():
     # Test when size is an int
     size = 224
-    resize_int = TfmResize(size)
+    resize_int = TfmResizeGPU(size)
     audio = test_audio_tensor()
     a2s = AudioToSpec.from_cfg(AudioConfig.Voice())
     sg = a2s(audio)

--- a/tests/test_spectrogram_augment.py
+++ b/tests/test_spectrogram_augment.py
@@ -13,9 +13,9 @@ from fastaudio.all import (
     AudioPadType,
     AudioToSpec,
     CropTime,
-    Delta,
     MaskFreq,
     MaskTime,
+    DeltaGPU,
     OpenAudio,
     Pipeline,
     ResizeSignal,
@@ -130,8 +130,9 @@ def test_resize_int():
 
 def test_delta_channels():
     " nchannels for a spectrogram is how many channels its original audio had "
-    delta = Delta()
-    audio = test_audio_tensor(channels=1)
+    delta = DeltaGPU()
+    # Explicitly check more than one channel
+    audio = test_audio_tensor(channels=2)
     a2s = AudioToSpec.from_cfg(AudioConfig.Voice())
     sg = a2s(audio)
     inp, out = apply_transform(delta, sg)


### PR DESCRIPTION
# Introduction

This PR adds GPU implementations for the following transforms:

- Signal: `AddNoise`, `ChangeVolume`, `SignalCutout`, `SignalLoss`
- Spectrogram: - `TfmResize`, `Delta`, `MaskFreq`, `MaskTime`

The GPU implementations are currently added alongside the originals, e.g. `Delta` vs. `DeltaGPU`. I propose replacing the originals outright where possible, but I've done a more thorough analysis with benchmarking below.

# Demos

I set up a Colab notebook with demos of the new transforms [here](https://colab.research.google.com/drive/1Tm2lCzdEqb7mcpouYcqti5ZwoSdPdOPr?usp=sharing). (It might make sense to turn this into documentation for all transforms at some point.)

# Automatic Batching

I've added a wrapper, [`@auto-batch`](https://github.com/jcaw/fastaudio/blob/a3b6bcef4f04e4161a1f80e2b6d3c7519e04dd64/src/fastaudio/util.py#L39-L73), that can be added to the `encodes` method of any batch transform to make it compatible with items too. You just need to specify the number of dimensions in a single item, and when item tensors are received, they will have a dummy batch dimension added for the transform. 

As a result, **all of these transforms work on both batches and items, with no user intervention.**

(The overhead of the wrapper is measured below.)

# Changes in Behaviour

Some methods have had their behaviour expanded/altered in the port.

### AudioTensor

1. `AddNoise` - the GPU version exposes a minimum value for the noise, and allows the transform to be applied to random items. I have seen certain nets degrade when noise is added to all samples, seemingly because they learn to always expect background noise and don't know how to deal with clean samples. Adding noise to a subset of items fixes this, so it seems a sensible addition.

   Noise values are also changed so the max & min are relative to **one standard deviation** of the original tensor, _not_ the range `-1` to `1`, so the noise level is consistent relative to the average of the signal. This has its own drawbacks (e.g. samples that are mostly silence get much less noise), so I'm not sure which method is better. Let me know which you prefer, I can change it easily.

   (Noise can also now be added directly to spectrograms too.)
2. `ChangeVolume` - no change.
3. `SignalCutout` - a minimum cutout percentage is now exposed.
4. `SignalLoss` - no change.

### AudioSpectrogram

1. `TfmResize` - no change.
2. `Delta` - the GPU version now uses `torchaudio` to compute deltas, and exposes the padding mode.
3. `MaskFreq` & `MaskTime` - the GPU version is modified to more closely match the original `SpecAugment` paper, with a couple of other additions.
  A. Masks are now assigned a random width (within a specified range).
  B. The replacement value is now the mean of the masked area, to avoid changing the spectrogram's overall mean (although the standard deviation will still be affected). This can be overridden by specifying a `mask_val`.
  C. You can no longer specify where you want the mask(s) to start. It's always random.
  D. One objective of SpecAugment masking seems to be encouraging the network to learn how to look at parts of the spectrogram it would otherwise ignore. The same mask will now span across all channels, to ensure the net does not avoid this by inferring the missing information from same region in another channel (which is likely to be quite similar).

# Benchmarks

I benchmarked the new transforms on two boxes:

1. Local - Nvidia GTX 970, i5-4590 (4 cores, 3.30GHz)
2. Colab - Tesla T4, Intel Xeon (2 cores, 2.20GHz)

Results are presented for both. Benchmarks are repeated 1000 times on the Colab box and 100 times locally, except for the `batch_size=64` tests, which are repeated 250 times on the Colab box and 25 times locally. These benchmarks are on the plain Python versions of the transforms, I haven't compiled them to torchscript. Let me know how you'd like me to interact with torchscript and whether you'd like me to benchmark that too.

Some results for the replacement delta transforms are missing on GPU due to an [upstream](https://github.com/pytorch/pytorch/issues/49601) bug affecting large tensors. It gets tripped due to the way `torchaudio` packs spectrograms for the delta method. This bug might not fire on newer cards (it may to be related to the maximum CUDA block size). I can pull `DeltaGPU` out into a separate PR if you'd like to wait until the upstream issues are fixed.

## Old vs. New Implementations

I compared the execution speed on CPU between the old and new methods to establish which of the new methods add unacceptable overhead and which should replace the old implementations. Benchmarking script [here](https://github.com/jcaw/fastaudio/blob/331e841d383e015662a338f117b827eeb561341d/scripts/perf_benchmark.py#L244-L281).

Results are split between `AudioTensor` and `AudioSpectrogram` objects. These operations are performed on single items with no batch dimension.

### AudioTensor

#### Colab (Xeon, x2 @ 2.20 GHz)

![device_name_plot](https://user-images.githubusercontent.com/40725916/104625966-3c7af280-568d-11eb-88c1-f834532696e6.png)

#### Local (i5-4590, x4 @ 3.30 GHz)

![device_name_plot](https://user-images.githubusercontent.com/40725916/104625937-338a2100-568d-11eb-921a-ebc2df1f7cef.png)

#### Conclusion

Based on these results I propose:

1. `AddNoise` - **replace**. The GPU-compatible version seems to have similar overhead, but does more.
2. `ChangeVolume` - **replace**. This method is so fast to begin with that the loss of efficiency is not likely to be significant relative to the entire pipeline. Auto-batching may also be responsible for a chunk of this.
3. `SignalCutout` - **undecided**. The GPU-compatible version is slower, but also allows a minimum cut percentage to be specified. If the original is kept, I think it should also add that.
4. `SignalLoss` - **replace**. The additional overhead of the GPU version appears minimal. I propose replacing for cleanliness.

### AudioSpectrogram

#### Colab (Xeon, 2 Cores @ 2.20 GHz)

![device_name_plot](https://user-images.githubusercontent.com/40725916/104626172-7b10ad00-568d-11eb-9034-d83ca1832af9.png)

#### Local (i5-4590, 4 Cores @ 3.30 GHz)

![device_name_plot](https://user-images.githubusercontent.com/40725916/104626207-8532ab80-568d-11eb-9c52-8349f6175997.png)

#### Conclusion

1. `TfmResize` - **replace**. The new implementation is comparable.
2. `Delta` - **replace**. The new implementation is much faster.
3. `MaskTime` - **replace**. The new implementation is comparable but does a lot more.
4. `MaskFreq` - **replace**. The new implementation is much slower but does a lot more. Interestingly, this shows the overhead of the conversion operations in the original `MaskTime` implementation - they dwarf the underlying transform.

## GPU Performance

I've also benchmarked the performance on GPU, to give an idea of how the new implementations scale and the relative overhead of the different operations.

I'm suspicious of the CPU vs. GPU results on the GTX 970 box. I think the GPU should be performing dramatically better (those that I've used in a real training loop have negligible overhead compared to their CPU counterparts), so there may be a problem in the benchmarking script. I believe the 970 also has strange memory characteristics that mean the upper portion of its VRAM is slow compared to the rest - I don't know if that would be affecting things.

### GPU Only, Various Batch Sizes

This is just to illustrate how each transform scales. Some transforms at larger batch sizes are missing due to CUDA memory errors.

#### Tesla T4

![batch_size_plot](https://user-images.githubusercontent.com/40725916/104626278-9b406c00-568d-11eb-9aba-0c1c31a4c3a0.png)
![batch_size_plot](https://user-images.githubusercontent.com/40725916/104626290-a0052000-568d-11eb-898e-8bd325ac0ab7.png)

#### GTX 970

![batch_size_plot](https://user-images.githubusercontent.com/40725916/104626400-c5922980-568d-11eb-8772-baa2a541eb11.png)
![batch_size_plot](https://user-images.githubusercontent.com/40725916/104626411-c9be4700-568d-11eb-8c67-1126216ad3f3.png)

### GPU vs. CPU, Batch Size = 32

#### Tesla T4

![device_name_plot](https://user-images.githubusercontent.com/40725916/104626315-aa271e80-568d-11eb-870c-6bf850da865d.png)
![device_name_plot](https://user-images.githubusercontent.com/40725916/104626324-aeebd280-568d-11eb-8a5d-b51da0f575a0.png)

#### GTX 970

![device_name_plot](https://user-images.githubusercontent.com/40725916/104626426-ce82fb00-568d-11eb-9fbb-e3bcf8dea394.png)
![device_name_plot](https://user-images.githubusercontent.com/40725916/104626449-d6db3600-568d-11eb-8204-550eda3f8eb5.png)

### GPU vs. CPU, Batch Size = 64

#### Tesla T4

![device_name_plot](https://user-images.githubusercontent.com/40725916/104626348-b612e080-568d-11eb-86f7-18e0ad5f27d1.png)
![device_name_plot](https://user-images.githubusercontent.com/40725916/104626365-bd39ee80-568d-11eb-95c1-4b0bb6b1a4ab.png)

#### GTX 970

![device_name_plot](https://user-images.githubusercontent.com/40725916/104626481-e35f8e80-568d-11eb-812b-eb046913c912.png)
![device_name_plot](https://user-images.githubusercontent.com/40725916/104626490-e78bac00-568d-11eb-8f2c-b2e04c50a352.png)

## Automatic Batching

I've [measured](https://github.com/jcaw/fastaudio/blob/75ee3dc33253b3331001fedf7a6c2b6abb5b05b7/scripts/perf_benchmark.py#L342-L364) two dummy transforms that do nothing - one with the `@auto_batch` wrapper and one without. The wrapper is very cheap, adding minimal overhead.

#### Colab (Tesla, Xeon)

![device_name_plot](https://user-images.githubusercontent.com/40725916/104628079-ba3ffd80-568f-11eb-899a-d85d5e2afdd8.png)

#### Local (970, i5-4590)

![device_name_plot](https://user-images.githubusercontent.com/40725916/104628061-b2805900-568f-11eb-9c4b-604f8a6ce2f0.png)

# Tests

Tests are not final. I've currently just switched them over to the GPU versions of the transforms. Once a final set of transforms has been decided, I can concretize the tests.

# Docstrings

Docstrings aren't final. I'll write them once the code is finalised. Let me know
what format you'd prefer.

# FastAI API Integration

I've currently set the transforms up as subclasses of the basic `Transform` class, but this might not be ideal. I'm not familiar enough with the subclasses of Transform to know if this is correct. Perhaps `DisplayedTransform` would be preferable?

# Conclusion

Let me know whether these implementations are acceptable and which of the original transforms you would like to keep/discard. I think it makes sense to merge these here initially, then I can look at upstreaming relevant transforms (E.g. the new SpecAugment masking implementation) into `torchaudio` or `torch-audiomentations`.
