### PR TITLE
Updating fastai to 2.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,12 +32,12 @@ setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 # install_requires = numpy; scipy
 install_requires =
-    fastai==2.2.7
-    torchaudio>=0.6
+    fastai==2.3.1
+    torchaudio>=0.7,<0.9
     librosa==0.8
     colorednoise>=1.1
-    IPython>=7.13
-    fastcore==1.3.19
+    IPython #Temporary remove the bound on IPython
+    fastcore==1.3.20
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,16 +59,12 @@ testing =
     papermill
     jupyter
 
-#TODO: mknotebooks is fixed at 0.5 until https://github.com/greenape/mknotebooks/issues/90
-# is fixed. When upgrading to 0.6+, remove the nbconvert==5.6.1 and markdown==3.2.1
 
 dev =
     mkdocs>=1.1
     mkautodoc>=0.1
     mkdocs-material>=5.5
-    mknotebooks==0.5
-    nbconvert==5.6.1
-    markdown==3.2.1
+    mknotebooks==0.6.1
     pre_commit>=2.7
     recommonmark>=0.6
     black>=19.10b0


### PR DESCRIPTION
This update tries to fix some dependency problems that happen, specially when using the library inside of kaggle or colab, where the default packages installed conflict with the ones specified at setup.cfg.
Also fastai is updated to the latest one.