### PR TITLE
Update to fastai 2.7.12

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ conda activate fastaudio
 # Editable install
 git clone https://github.com/fastaudio/fastaudio.git
 cd fastaudio
-pip install -e .[dev,testing]
+pip install -e '.[dev,testing]'
 pre-commit install
 ```
 
@@ -62,7 +62,7 @@ Create issues, write documentation, suggest/add features, submit PRs. We are ope
 This project has been set up using PyScaffold 3.2.3. For details and usage
 information on PyScaffold see https://pyscaffold.org/.
 
-## Community 
+## Community
 
 Please come and ask us questions about audio related tasks in our [discord](https://discord.gg/gfNYcfX6pM)
 

--- a/docs/ESC50: Environmental Sound Classification.ipynb
+++ b/docs/ESC50: Environmental Sound Classification.ipynb
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "#The first time this will download a dataset that is ~650mb\n",
-    "path = untar_data(URLs.ESC50, dest=\"ESC50\")"
+    "path = untar_data(URLs.ESC50)"
    ]
   },
   {

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,12 +32,11 @@ setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 # install_requires = numpy; scipy
 install_requires =
-    fastai==2.3.1
-    torchaudio>=0.7,<0.9
-    librosa==0.8
+    fastai==2.7.12
+    torchaudio>=2.0.0
+    librosa==0.10.0
     colorednoise>=1.1
-    IPython #Temporary remove the bound on IPython
-    fastcore==1.3.20
+    fastcore==1.5.29
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/fastaudio/core/signal.py
+++ b/src/fastaudio/core/signal.py
@@ -12,7 +12,7 @@ from fastcore.dispatch import typedispatch
 from fastcore.meta import delegates
 from fastcore.utils import ifnone
 from IPython.display import Audio, display
-from librosa.display import waveplot
+from librosa.display import waveshow
 from os import path
 
 audio_extensions = tuple(
@@ -143,6 +143,10 @@ class AudioTensor(TensorBase):
             raise Exception("File already exists")
         torchaudio.save(fn, self.data, self.sr)
 
+    def clone(self, *, memory_format=None):
+        c = super().clone(memory_format=memory_format)
+        setattr(c, "sr", self.sr)
+        return c
 
 def show_audio_signal(ai, ctx, ax=None, title="", **kwargs):
     ax = ifnone(ax, ctx)
@@ -152,7 +156,7 @@ def show_audio_signal(ai, ctx, ax=None, title="", **kwargs):
     for i, channel in enumerate(ai):
         # x_start, y_start, x_lenght, y_lenght, all in percent
         ia = ax.inset_axes((i / ai.nchannels, 0.2, 1 / ai.nchannels, 0.7))
-        waveplot(channel.cpu().numpy(), ai.sr, ax=ia, **kwargs)
+        waveshow(channel.cpu().numpy(), sr=ai.sr, ax=ia, **kwargs)
         ia.set_title(f"Channel {i}")
     ax.set_title(title)
 

--- a/src/fastaudio/core/spectrogram.py
+++ b/src/fastaudio/core/spectrogram.py
@@ -1,3 +1,4 @@
+import copy
 import torchaudio
 import warnings
 from dataclasses import asdict, is_dataclass
@@ -75,6 +76,12 @@ class AudioSpectrogram(TensorImageBase):
     def show(self, ctx=None, ax=None, title="", **kwargs):
         "Show spectrogram using librosa"
         return show_spectrogram(self, ctx=ctx, ax=ax, title=title, **kwargs)
+
+    def clone(self, *, memory_format=None):
+        c = super().clone(memory_format=memory_format)
+        if hasattr(self, "settings"):
+            setattr(c, "_settings", copy.deepcopy(getattr(self, "settings")))
+        return c
 
 
 def show_spectrogram(sg, title="", ax=None, ctx=None, **kwargs):


### PR DESCRIPTION
Updated the following libraries
```
fastai==2.7.12
torchaudio>=2.0.0
fastcore==1.5.29
librosa==0.10.0
```

I also ran the tests on my environment which contains python 3.11.3 and the following libraries installed
Note that I had to run `pip install --pre numba` to make `librosa==0.10.0` work with python 3.11.3

```
alabaster==0.7.13
ansiwrap==0.8.4
anyio==3.6.2
argon2-cffi==21.3.0
argon2-cffi-bindings==21.2.0
arrow==1.2.3
asttokens==2.2.1
attrs==23.1.0
audioread==3.0.0
Babel==2.12.1
backcall==0.2.0
beautifulsoup4==4.12.2
black==23.3.0
bleach==6.0.0
blis==0.7.9
catalogue==2.0.8
certifi==2022.12.7
cffi==1.15.1
cfgv==3.3.1
charset-normalizer==3.1.0
click==8.1.3
cmake==3.26.3
colorama==0.4.6
colorednoise==2.1.0
comm==0.1.3
commonmark==0.9.1
confection==0.0.4
contourpy==1.0.7
coverage==7.2.3
cycler==0.11.0
cymem==2.0.7
debugpy==1.6.7
decorator==5.1.1
defusedxml==0.7.1
distlib==0.3.6
docutils==0.19
entrypoints==0.4
executing==1.2.0
fastai==2.7.12
fastcore==1.5.29
fastdownload==0.0.7
fastjsonschema==2.16.3
fastprogress==1.0.3
filelock==3.12.0
fonttools==4.39.3
fqdn==1.5.1
ghp-import==2.1.0
gitdb==4.0.10
GitPython==3.1.31
identify==2.5.22
idna==3.4
imagesize==1.4.1
iniconfig==2.0.0
ipykernel==6.22.0
ipython==8.12.0
ipython-genutils==0.2.0
ipywidgets==8.0.6
isoduration==20.11.0
jedi==0.18.2
Jinja2==3.1.2
joblib==1.2.0
jsonpointer==2.3
jsonschema==4.17.3
jupyter==1.0.0
jupyter-console==6.6.3
jupyter-events==0.6.3
jupyter_client==8.2.0
jupyter_core==5.3.0
jupyter_server==2.5.0
jupyter_server_terminals==0.4.4
jupyterlab-pygments==0.2.2
jupyterlab-widgets==3.0.7
kiwisolver==1.4.4
langcodes==3.3.0
lazy_loader==0.2
librosa==0.10.0
lit==16.0.1
llvmlite==0.40.0rc1
Markdown==3.3.7
MarkupSafe==2.1.2
matplotlib==3.7.1
matplotlib-inline==0.1.6
mergedeep==1.3.4
mistune==2.0.5
mkautodoc==0.2.0
mkdocs==1.4.2
mkdocs-material==9.1.7
mkdocs-material-extensions==1.1.1
mknotebooks==0.6.1
mpmath==1.3.0
msgpack==1.0.5
murmurhash==1.0.9
mypy-extensions==1.0.0
nbclassic==0.5.5
nbclient==0.7.3
nbconvert==7.3.1
nbformat==5.8.0
nest-asyncio==1.5.6
networkx==3.1
nodeenv==1.7.0
notebook==6.5.4
notebook_shim==0.2.2
numba==0.57.0rc1
numpy==1.24.2
nvidia-cublas-cu11==11.10.3.66
nvidia-cuda-cupti-cu11==11.7.101
nvidia-cuda-nvrtc-cu11==11.7.99
nvidia-cuda-runtime-cu11==11.7.99
nvidia-cudnn-cu11==8.5.0.96
nvidia-cufft-cu11==10.9.0.58
nvidia-curand-cu11==10.2.10.91
nvidia-cusolver-cu11==11.4.0.1
nvidia-cusparse-cu11==11.7.4.91
nvidia-nccl-cu11==2.14.3
nvidia-nvtx-cu11==11.7.91
packaging==23.1
pandas==2.0.0
pandocfilters==1.5.0
papermill==2.4.0
parso==0.8.3
pathspec==0.11.1
pathy==0.10.1
pexpect==4.8.0
pickleshare==0.7.5
Pillow==9.5.0
platformdirs==3.2.0
pluggy==1.0.0
pooch==1.7.0
pre-commit==3.2.2
preshed==3.0.8
prometheus-client==0.16.0
prompt-toolkit==3.0.38
psutil==5.9.5
ptyprocess==0.7.0
pure-eval==0.2.2
pycparser==2.21
pydantic==1.10.7
Pygments==2.15.1
pymdown-extensions==9.11
pyparsing==3.0.9
pyrsistent==0.19.3
pytest==7.3.1
pytest-cov==4.0.0
python-dateutil==2.8.2
python-json-logger==2.0.7
pytz==2023.3
PyYAML==6.0
pyyaml_env_tag==0.1
pyzmq==25.0.2
qtconsole==5.4.2
QtPy==2.3.1
recommonmark==0.7.1
regex==2023.3.23
requests==2.28.2
rfc3339-validator==0.1.4
rfc3986-validator==0.1.1
scikit-learn==1.2.2
scipy==1.10.1
Send2Trash==1.8.0
six==1.16.0
smart-open==6.3.0
smmap==5.0.0
sniffio==1.3.0
snowballstemmer==2.2.0
soundfile==0.12.1
soupsieve==2.4.1
soxr==0.3.5
spacy==3.5.2
spacy-legacy==3.0.12
spacy-loggers==1.0.4
Sphinx==6.1.3
sphinxcontrib-applehelp==1.0.4
sphinxcontrib-devhelp==1.0.2
sphinxcontrib-htmlhelp==2.0.1
sphinxcontrib-jsmath==1.0.1
sphinxcontrib-qthelp==1.0.3
sphinxcontrib-serializinghtml==1.1.5
srsly==2.4.6
stack-data==0.6.2
sympy==1.11.1
tenacity==8.2.2
terminado==0.17.1
textwrap3==0.9.2
thinc==8.1.9
threadpoolctl==3.1.0
tinycss2==1.2.1
torch==2.0.0
torchaudio==2.0.1
torchvision==0.15.1
tornado==6.3.1
tqdm==4.65.0
traitlets==5.9.0
triton==2.0.0
typer==0.7.0
typing_extensions==4.5.0
tzdata==2023.3
uri-template==1.2.0
urllib3==1.26.15
virtualenv==20.22.0
wasabi==1.1.1
watchdog==3.0.0
wcwidth==0.2.6
webcolors==1.13
webencodings==0.5.1
websocket-client==1.5.1
widgetsnbextension==4.0.7
```
