### PR TITLE
colored_noise: fix device for white noise

### DIFF
--- a/src/fastaudio/augment/functional.py
+++ b/src/fastaudio/augment/functional.py
@@ -177,7 +177,7 @@ def colored_noise(shape, exponent, fmin=0, device=None):
     # Use `is` to allow for tensor exponents
     if exponent is NoiseColor.White:
         # White noise is simple - use a faster method.
-        return torch.randn(shape)
+        return torch.randn(shape, device=device)
 
     # The number of samples in each time series
     nsamples = shape[-1]


### PR DESCRIPTION
When colored_noise was used to generate white noise, the device parameter was not respected.